### PR TITLE
fix for broken filtering

### DIFF
--- a/questioner/static/questioner/search_filter.js
+++ b/questioner/static/questioner/search_filter.js
@@ -52,7 +52,7 @@ function search_filter() {
     for (var i = 0; i < questions.length; i++) {
         var level = questions[i].getElementsByClassName("difficulty")[0].innerHTML; 
         var type = questions[i].getElementsByClassName("q_type")[0].innerHTML;
-        var q_name = questions[i].getElementsByClassName("accordion")[0].getElementsByTagName("h3")[0]; 
+        var q_name = questions[i].getElementsByClassName("accordion")[0].getElementsByClassName("challenge_title")[0]; 
         if (is_reviewer) {
             var avail = (
                 q_avail === "all" || 


### PR DESCRIPTION
oops.  when tweaking the accordion to fit in cert titles, I changed the challenge titles from h3 to a div.  little did I know, the filter was using getElementsByTagName('h3').  fixed now.